### PR TITLE
Remove patternID

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ This polyfill uses CSS feature detection and if ```-webkit-background-clip: text
 
 ```xml
 <svg>
-  <pattern id="mypattern" patternUnits="userSpaceOnUse" width="750" height="800">
+  <pattern id="headline-pattern" patternUnits="userSpaceOnUse" width="750" height="800">
     <image width="750" height="800" xlink:href="http://timpietrusky.com/cdn/army.png"></image>
   </pattern>
-  <text x="0" y="80" class="headline" style="fill:url(#mypattern);">background-clip: text | Polyfill</text>
+  <text x="0" y="80" class="headline" style="fill:url(#headline-pattern);">background-clip: text | Polyfill</text>
 </svg>
 ```
 
@@ -42,12 +42,10 @@ var element = document.querySelector('.myelement');
 /*
  * Call the polyfill
  *
- * patternID : the unique ID of the SVG pattern
  * patternURL : the URL to the background-image
  * class : the css-class applied to the SVG
  */
 element.backgroundClipPolyfill({
-  'patternID' : 'mypattern',
   'patternURL' : 'url/to/background/pattern',
   'class' : 'myelement'
 });

--- a/background-clip-text-polyfill.js
+++ b/background-clip-text-polyfill.js
@@ -9,7 +9,6 @@
 
   var element = document.querySelector('.myelement'); 
   element.backgroundClipPolyfill({
-    'patternID' : 'mypattern',
     'patternURL' : 'url/to/background/pattern',
     'class' : 'myelement'
   });
@@ -17,7 +16,6 @@
  * 
  * Variables:
  *
- * patternID : the unique ID of the SVG pattern
  * patternURL : the URL to the background-image
  * class : the css-class applied to the SVG
  *
@@ -54,7 +52,7 @@ Element.prototype.backgroundClipPolyfill = function () {
     
     // Add attributes to elements
     addAttributes(pattern, {
-      'id' : a.id,
+      'id' : a['class'] + '-pattern',
       'patternUnits' : 'userSpaceOnUse',
       'width' : a.width,
       'height' : a.height
@@ -69,8 +67,8 @@ Element.prototype.backgroundClipPolyfill = function () {
     addAttributes(text, {
       'x' : 0,
       'y' : 80,
-      'class' : a.class,
-      'style' : 'fill:url(#' + a.id + ');'
+      'class' : a['class'],
+      'style' : 'fill:url(#' + a['class'] + '-pattern);'
     });
     
     // Set text
@@ -94,9 +92,9 @@ Element.prototype.backgroundClipPolyfill = function () {
     var img = new Image();
     img.onload = function() {
       var svg = createSVG({
-        'id' : a.patternID,
+        'id' : a['class'] + '-pattern',
         'url' : a.patternURL,
-        'class' : a.class,
+        'class' : a['class'],
         'width' : this.width,
         'height' : this.height,
         'text' : el.textContent


### PR DESCRIPTION
I don't think that there's a use-case for the `patternID` property, since you can easily [use the polyfill on multiple unique elements that share a class](http://codepen.io/ChristianBundy/pen/Kstnm) by using the polyfill method only on the element that you want it active on.

I think that the `patternID` was a great idea for making sure that the polyfill is only active when it's supposed to be, but since `element.backgroundClipPolyfill()` only runs on `element`, it's safe to remove without any side-effects. 

This pull request is also backward compatible, as long as the old version doesn't run the method on elements that aren't supposed to be polyfilled (which isn't the intended use for this anyway).
